### PR TITLE
사용자 관심사 선택 및 저장 기능 구현

### DIFF
--- a/src/main/java/com/univ/memoir/api/controller/UserController.java
+++ b/src/main/java/com/univ/memoir/api/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.univ.memoir.api.controller;
+
+import com.univ.memoir.api.dto.req.UserInterestRequest;
+import com.univ.memoir.api.dto.res.UserProfileDto;
+import com.univ.memoir.api.exception.codes.SuccessCode;
+import com.univ.memoir.api.exception.responses.SuccessResponse;
+import com.univ.memoir.core.domain.User;
+import com.univ.memoir.core.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "사용자", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserService userService;
+    @PostMapping("/category")
+    @Operation(summary = "관심사 카테고리 선택 ", description = "사용자 관심사 카테고리를 선택합니다.")
+    public ResponseEntity<?> updateInterestsByToken(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody UserInterestRequest request
+    ) {
+        User updatedUser = userService.updateUserInterestsByToken(accessToken, request.getInterests());
+        return SuccessResponse.of(SuccessCode.UPDATED, new UserProfileDto(updatedUser));
+    }
+}

--- a/src/main/java/com/univ/memoir/api/dto/req/UserInterestRequest.java
+++ b/src/main/java/com/univ/memoir/api/dto/req/UserInterestRequest.java
@@ -1,0 +1,16 @@
+package com.univ.memoir.api.dto.req;
+
+import com.univ.memoir.core.domain.InterestType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+public class UserInterestRequest {
+
+    @NotEmpty
+    @Size(max = 5, message = "관심사는 최대 5개까지 선택할 수 있습니다.")
+    private Set<InterestType> interests;
+}

--- a/src/main/java/com/univ/memoir/api/dto/res/UserProfileDto.java
+++ b/src/main/java/com/univ/memoir/api/dto/res/UserProfileDto.java
@@ -1,0 +1,25 @@
+package com.univ.memoir.api.dto.res;
+
+import com.univ.memoir.core.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileDto {
+    private Long id;
+    private String email;
+    private String name;
+    private String profileUrl;
+
+    public UserProfileDto(User user){
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.profileUrl = user.getProfileUrl();
+    }
+}

--- a/src/main/java/com/univ/memoir/api/exception/customException/InvalidTokenException.java
+++ b/src/main/java/com/univ/memoir/api/exception/customException/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package com.univ.memoir.api.exception.customException;
+
+import com.univ.memoir.api.exception.GlobalException;
+import com.univ.memoir.api.exception.codes.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends GlobalException {
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/univ/memoir/api/exception/customException/UserNotFoundException.java
+++ b/src/main/java/com/univ/memoir/api/exception/customException/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.univ.memoir.api.exception.customException;
+
+import com.univ.memoir.api.exception.GlobalException;
+import com.univ.memoir.api.exception.codes.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserNotFoundException extends GlobalException{
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+
+

--- a/src/main/java/com/univ/memoir/config/SwaggerConfig.java
+++ b/src/main/java/com/univ/memoir/config/SwaggerConfig.java
@@ -3,19 +3,30 @@ package com.univ.memoir.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI openAPI() {
-        Info info = new Info()
-                .title("Collec API Document")
-                .version("v0.0.1")
-                .description("collec API 문서입니다.");
+        String jwtSchemeName = "JWT";
+
         return new OpenAPI()
-                .components(new Components())
-                .info(info);
+                .info(new Info()
+                        .title("Collec API Document")
+                        .version("v0.0.1")
+                        .description("collec API 문서입니다."))
+                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName,
+                                new SecurityScheme()
+                                        .name("Authorization")      // header 이름
+                                        .type(SecurityScheme.Type.APIKEY) // bearer 대신 apiKey
+                                        .in(SecurityScheme.In.HEADER)     // 헤더에 설정
+                        ));
     }
 }

--- a/src/main/java/com/univ/memoir/config/jwt/JwtProvider.java
+++ b/src/main/java/com/univ/memoir/config/jwt/JwtProvider.java
@@ -16,16 +16,26 @@ public class JwtProvider {
     @Value("${spring.security.jwt.secret}")
     private String secretKey;
 
-    private static final long EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 1일
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 60; // 1시간
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24 * 14; // 14일
 
     @PostConstruct
     protected void init() {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    public String createToken(String email) {
+    public String createAccessToken(String email) {
+        return createToken(email, ACCESS_TOKEN_EXPIRATION);
+    }
+
+    public String createRefreshToken(String email) {
+        return createToken(email, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    // 내부 토큰 생성 로직
+    private String createToken(String email, long expirationTime) {
         Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + EXPIRATION_TIME);
+        Date expiryDate = new Date(now.getTime() + expirationTime);
 
         return Jwts.builder()
                 .setSubject(email)

--- a/src/main/java/com/univ/memoir/config/jwt/OAuth2SuccessHandler.java
+++ b/src/main/java/com/univ/memoir/config/jwt/OAuth2SuccessHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -15,8 +16,10 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    @Value("${oauth2.redirect-uri}")
+    private String redirectUri;
+
     private final JwtProvider jwtProvider;
-    private static final String REDIRECT_URI = "http://localhost:3000/oauth/callback"; // 프론트 콜백 주소
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -24,7 +27,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // AccessToken 생성
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
-        String accessToken = jwtProvider.createToken(email);
+        String accessToken = jwtProvider.createAccessToken(email);
 
 
         // AccessToken을 HttpOnly 쿠키로 설정
@@ -37,6 +40,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessTokenCookie);
 
         // 프론트로 리디렉트
-        response.sendRedirect(REDIRECT_URI);
+        response.sendRedirect(redirectUri);
     }
 }

--- a/src/main/java/com/univ/memoir/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/univ/memoir/config/jwt/SecurityConfig.java
@@ -5,6 +5,8 @@ import com.univ.memoir.core.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,20 +22,23 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
-    public CustomOAuth2UserService customOAuth2UserService(UserRepository userRepository) {
-        return new CustomOAuth2UserService(userRepository);
+    public CustomOAuth2UserService customOAuth2UserService(UserRepository userRepository, JwtProvider jwtProvider) {
+        return new CustomOAuth2UserService(userRepository, jwtProvider);
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService) throws Exception {
         http
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .cors(Customizer.withDefaults()) // CORS 설정 활성화
+                .csrf(AbstractHttpConfigurer::disable)
+
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/**").permitAll()  // API 요청 열기 (이후 JWT 필터 적용)
                         .anyRequest().authenticated()
                 )
+
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/com/univ/memoir/core/domain/InterestType.java
+++ b/src/main/java/com/univ/memoir/core/domain/InterestType.java
@@ -1,0 +1,19 @@
+package com.univ.memoir.core.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum InterestType {
+    WORK("업무"),
+    STUDY("공부"),
+    NEWS("뉴스"),
+    CONTENTS("콘텐츠"),
+    SHOPPING("쇼핑");
+
+    private final String categoryName;
+
+    InterestType(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+}

--- a/src/main/java/com/univ/memoir/core/domain/User.java
+++ b/src/main/java/com/univ/memoir/core/domain/User.java
@@ -10,6 +10,7 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "user")
 public class User {
 
     @Id
@@ -34,13 +35,11 @@ public class User {
     @Column(length = 1, nullable = false)
     private String status = "N"; // 'N' = 정상 / 'Y' = 탈퇴
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "user_interest",
-            joinColumns = @JoinColumn(name = "user_id"),
-            inverseJoinColumns = @JoinColumn(name = "interest_id")
-    )
-    private Set<Interest> interests = new HashSet<>();
+    @ElementCollection(targetClass = InterestType.class, fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_interests", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interest")
+    private Set<InterestType> interests = new HashSet<>();
 
     @Builder
     public User(String googleId, String email, String name, String profileUrl, String refreshToken) {
@@ -73,12 +72,10 @@ public class User {
         return "N".equals(this.status);
     }
 
-    public void addInterest(Interest interest) {
-        this.interests.add(interest);
+    public void updateInterests(Set<InterestType> newInterests) {
+        this.interests.clear();
+        this.interests.addAll(newInterests);
     }
 
-    public void removeInterest(Interest interest) {
-        this.interests.remove(interest);
-    }
 
 }

--- a/src/main/java/com/univ/memoir/core/repository/UserRepository.java
+++ b/src/main/java/com/univ/memoir/core/repository/UserRepository.java
@@ -9,5 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGoogleId(String googleId);
+
+    Optional<User> findByRefreshToken(String refreshToken);
+
 }
 

--- a/src/main/java/com/univ/memoir/core/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/univ/memoir/core/service/CustomOAuth2UserService.java
@@ -2,6 +2,7 @@ package com.univ.memoir.core.service;
 
 import com.univ.memoir.api.exception.codes.ErrorCode;
 import com.univ.memoir.config.jwt.CustomOAuth2User;
+import com.univ.memoir.config.jwt.JwtProvider;
 import com.univ.memoir.core.domain.User;
 import com.univ.memoir.core.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -31,11 +33,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             throw new OAuth2AuthenticationException("Google 계정 정보를 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.");
         }
 
+        String refreshToken = jwtProvider.createRefreshToken(email);
+
         User user = userRepository.findByGoogleId(googleId)
                 .map(existingUser -> {
                     // 기존 사용자 정보 업데이트 가능
                     existingUser.updateName(name);
                     existingUser.updateProfileUrl(picture);
+                    existingUser.updateRefreshToken(refreshToken);
                     return userRepository.save(existingUser);
                 })
                 .orElseGet(() -> userRepository.save(User.builder()
@@ -43,6 +48,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                         .email(email)
                         .name(name)
                         .profileUrl(picture)
+                        .refreshToken(refreshToken)
                         .build()));
 
         return new CustomOAuth2User(user, oAuth2User.getAttributes());

--- a/src/main/java/com/univ/memoir/core/service/UserService.java
+++ b/src/main/java/com/univ/memoir/core/service/UserService.java
@@ -1,0 +1,49 @@
+package com.univ.memoir.core.service;
+
+import com.univ.memoir.api.exception.codes.ErrorCode;
+import com.univ.memoir.api.exception.customException.InvalidTokenException;
+import com.univ.memoir.api.exception.customException.UserNotFoundException;
+import com.univ.memoir.core.domain.InterestType;
+import com.univ.memoir.core.domain.User;
+import com.univ.memoir.core.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public Long getUserIdFromToken(String accessToken) {
+        return userRepository.findByRefreshToken(accessToken)
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND))
+                .getId();
+    }
+
+    @Transactional
+    public User updateUserInterestsByToken(String accessToken, Set<InterestType> interests) {
+        User user = userRepository.findByRefreshToken(accessToken)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_JWT_ACCESS_TOKEN));
+        user.updateInterests(interests);
+        return user;
+    }
+
+    public List<String> getUserInterests(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        return user.getInterests()
+                .stream()
+                .map(InterestType::getCategoryName) // 예: "STUDY", "NEWS" 등의 문자열 반환
+                .collect(Collectors.toList());
+    }
+
+
+
+}


### PR DESCRIPTION
## Issue Number

* Close #4 

## Key Changes

사용자 관심사 선택 및 저장 기능 구현

* `InterestType` enum 생성 및 관심사 목록 정의 (WORK, STUDY, NEWS, CONTENTS, SHOPPING)
* 관심사 선택 요청 DTO (`UserInterestRequest`) 생성
* `User` 엔티티에 관심사 필드(`Set<InterestType>`) 추가 및 수정 메서드 구현
* 관심사 저장 API (`POST /api/users/category`) 컨트롤러 추가
* JWT 토큰 기반 사용자 조회 및 관심사 업데이트 로직 구현
* 선택한 관심사를 유저 응답 DTO (`UserProfileDto`)에 포함

## To Reviewers

* 관심사 최대 개수 제한 로직이 적절한지 확인 부탁드립니다.
* JWT 인증 처리 및 사용자 정보 업데이트 과정에서 보안이나 성능 이슈가 없는지 검토해주세요.

## PR CheckList

* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
* [x] 변경 사항에 대한 테스트를 진행했습니다.
* [x] Postman 또는 유사 도구로 API 테스트 완료했습니다.
* [x] Reviewer 추가 및 단톡방에 공유했습니다.
