### PR TITLE
OAuth2 로그인 시 신규회원 여부 판단 로직 추가

### DIFF
--- a/src/main/java/com/univ/memoir/core/repository/UserRepository.java
+++ b/src/main/java/com/univ/memoir/core/repository/UserRepository.java
@@ -12,5 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
 
+    boolean existsByGoogleId(String GoogleId);
+
 }
 


### PR DESCRIPTION
## Issue Number

* Close #10  

## Key Changes

* OAuth2 로그인 성공 시 신규회원 여부를 판단하는 로직 추가
* `CustomOAuth2UserService`에서 `isNewUser` 판단 후 `OAuth2User` attributes에 포함
* `OAuth2SuccessHandler`에서 `isNewUser` 값을 활용하여 온보딩 URL과 기본 URL로 분기 처리
* `UserRepository`에 `existsByGoogleId` 메서드 추가

## To Reviewers

* 신규회원 여부 판단 방식 (`existsByGoogleId`)이 적절한지 검토 부탁드립니다.
* `OAuth2User` attribute에 부가 정보를 포함시키는 방식이 적절한지 확인 부탁드립니다.
* 핸들러 분기 처리에 문제 없는지 점검 부탁드립니다.

_프론트엔드에 빠르게 공유하기 위해 이번에는 RV 없이 바로 머지하겠습니다._

## PR CheckList

* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
* [x] 변경 사항에 대한 테스트를 진행했습니다.
* [x] OAuth2 로그인 및 신규회원 분기 테스트 완료했습니다.
* [x] Reviewer 추가 및 단톡방에 공유했습니다.
