### PR TITLE
OAuth2 SuccessHandler 리팩토링 및 SecurityConfig/CORS 설정 보완 

### DIFF
--- a/src/main/java/com/univ/memoir/config/WebConfig.java
+++ b/src/main/java/com/univ/memoir/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:3000", "https://memoir.asia")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/univ/memoir/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/univ/memoir/config/jwt/SecurityConfig.java
@@ -32,16 +32,20 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults()) // CORS 설정 활성화
                 .csrf(AbstractHttpConfigurer::disable)
 
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/**").permitAll()  // API 요청 열기 (이후 JWT 필터 적용)
+                        .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()
                 )
 
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
+                        .failureHandler((request, response, exception) -> {
+                            response.sendRedirect("/login?error");
+                        })
                 );
 
         return http.build();


### PR DESCRIPTION
## Issue Number
* Close #18

## Key Changes 
* OAuth2 로그인 성공 시 accessToken을 URL 쿼리 파라미터로 전달하도록 변경
  - 기존 쿠키 방식 제거 (Set-Cookie → redirect with token)
  - 신규 회원 여부(`isNewUser`)도 함께 전달
* SecurityConfig 설정 수정
  - `/api/**` 경로에 인증 필요하도록 수정
  - permitAll 대상 최소화
  - SuccessHandler 적용 유지
* CORS 설정 변경
  - 운영 도메인를 허용 origin에 추가
  - `allowCredentials(true)` 유지

## To Be Developed
* 쿼리 파라미터로 전달된 accessToken의 보안성에 대한 프론트 처리 검토
* 프론트에서 accessToken 저장 후 URL 정리 로직 구현 여부
* 운영 환경에서의 CORS 적용 상태 점검 및 로깅

## PR CheckList
* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
* [x] 변경 사항에 대한 테스트를 진행했습니다.
* [x] Postman 또는 유사 도구로 API 테스트 완료했습니다.
* [x] Reviewer 추가 및 단톡방에 공유했습니다.
